### PR TITLE
prettier: Add proseWrap=always for markdown files

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "generate-metadata": "ts-node scripts/generate-metadata && yarn format",
     "format": "yarn _prettier --write",
     "lint": "yarn _prettier --check",
-    "_prettier": "prettier \"{v*/**/*,*}.{js,jsx,ts,tsx,json,md,mdx,yaml,yml}\""
+    "_prettier": "prettier \"{v*/docs/*,*}.{js,jsx,ts,tsx,json,md,mdx,yaml,yml}\""
   },
   "devDependencies": {
     "@types/node": "^12.0.0",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   semi: false,
   singleQuote: true,
+  proseWrap: 'always',
 }

--- a/v1.0.0/docs/01-getting-started.mdx
+++ b/v1.0.0/docs/01-getting-started.mdx
@@ -1,6 +1,7 @@
 # Getting Started
 
-We create our own Edtr.io-powered WYSIWYG editor during this tutorial. It is divided into several sections:
+We create our own Edtr.io-powered WYSIWYG editor during this tutorial. It is
+divided into several sections:
 
 - [Setup](#setup)
 - [Creating the editor](#creating-the-editor)
@@ -10,7 +11,8 @@ We create our own Edtr.io-powered WYSIWYG editor during this tutorial. It is div
 
 ## Prerequisites
 
-We'll assume that you are familiar with React and the npm ecosystem. If you need to review your knowledge, we recommend the
+We'll assume that you are familiar with React and the npm ecosystem. If you need
+to review your knowledge, we recommend the
 [official React Tutorial](https://reactjs.org/tutorial/tutorial.html).
 
 ## <a name="setup" /> Setup
@@ -24,8 +26,9 @@ yarn add @edtr-io/core@^1.0.0 react@^16.8.0 react-dom@^16.8.0 react-is@^16.8.0 r
 npm i --save @edtr-io/core@^1.0.0 react@^16.8.0 react-dom@^16.8.0 react-is@^16.8.0 react-dnd@^11.0.0 react-dnd-html5-backend@^11.0.0 redux@^4.0.0 styled-components@^5.0.0
 ```
 
-Furthermore, we need at least one plugin. There are some "official" plugins provided by Edtr.io (though none of these are required). Let's start
-with the text plugin:
+Furthermore, we need at least one plugin. There are some "official" plugins
+provided by Edtr.io (though none of these are required). Let's start with the
+text plugin:
 
 ```bash
 # Using yarn
@@ -65,30 +68,38 @@ export default function App() {
   line <code>import 'regenerator-runtime/runtime'</code> to the top of the file.
 </Note>
 
-At this point, we should have a glorified rich-text editor. Let's go over the things we did in detail:
+At this point, we should have a glorified rich-text editor. Let's go over the
+things we did in detail:
 
-Firstly, we initialized an Edtr.io plugin using the `createTextPlugin` factory provided by `@edtr-io/plugin-text`.
-Like every "official" Edtr.io plugin, this factory accepts a config specific to the plugin. Some options are required
-(e.g. `registry`), while others are optional (e.g. `placeholder`).
+Firstly, we initialized an Edtr.io plugin using the `createTextPlugin` factory
+provided by `@edtr-io/plugin-text`. Like every "official" Edtr.io plugin, this
+factory accepts a config specific to the plugin. Some options are required (e.g.
+`registry`), while others are optional (e.g. `placeholder`).
 
 <Note>
   The factory pattern used by the "official" Edtr.io plugins is only a
   convention. Feel free to write your own plugins the way you like.
 </Note>
 
-After that, we specified the plugins that our editor should know about. This is a mapping of (arbitrary) keys to Edtr.io plugins.
-You can name the plugins how you prefer (e.g. `rich-text` instead of `text`), and they will appear in the serialized Edtr.io state.
+After that, we specified the plugins that our editor should know about. This is
+a mapping of (arbitrary) keys to Edtr.io plugins. You can name the plugins how
+you prefer (e.g. `rich-text` instead of `text`), and they will appear in the
+serialized Edtr.io state.
 
-The last thing we need is the state our editor should start with. The state describes an Edtr.io document and will be used to initialize
-the store. A document consists of the plugin used (i.e. with the same name as declared in `plugins`) and an optional state. If no
-state is provided (like in our example), the plugin creates its own initial state (e.g. empty text in our case).
+The last thing we need is the state our editor should start with. The state
+describes an Edtr.io document and will be used to initialize the store. A
+document consists of the plugin used (i.e. with the same name as declared in
+`plugins`) and an optional state. If no state is provided (like in our example),
+the plugin creates its own initial state (e.g. empty text in our case).
 
-Lastly, we render the `Editor` component provided by `@edtr-io/core` with the allowed plugins and the initial state.
+Lastly, we render the `Editor` component provided by `@edtr-io/core` with the
+allowed plugins and the initial state.
 
 ## <a name="nesting-documents" /> Nesting Documents
 
-The whole thing becomes much more interesting when we nest documents: Plugins may contain other Edtr.io documents and therefore create a tree
-of documents. The rows plugin provided by Edtr.io, for example, renders a list of documents.
+The whole thing becomes much more interesting when we nest documents: Plugins
+may contain other Edtr.io documents and therefore create a tree of documents.
+The rows plugin provided by Edtr.io, for example, renders a list of documents.
 
 First, we install the rows plugin
 
@@ -137,9 +148,12 @@ export default function App() {
 }
 ```
 
-We created the rows plugin via `createRowsPlugin` similarly to our text plugin. The rows plugin requires `content` which specifies which plugin
-should be used by default, and `plugins` which defines the plugins that may be added, including some metadata (e.g. a human-readable `title`).
-After that, we added the rows plugin to our known `plugins`, and replaced the initial state to start with the rows plugin.
+We created the rows plugin via `createRowsPlugin` similarly to our text plugin.
+The rows plugin requires `content` which specifies which plugin should be used
+by default, and `plugins` which defines the plugins that may be added, including
+some metadata (e.g. a human-readable `title`). After that, we added the rows
+plugin to our known `plugins`, and replaced the initial state to start with the
+rows plugin.
 
 <Note>
   The <code>plugins</code> passed to the <code>Editor</code> component are not
@@ -155,9 +169,10 @@ After that, we added the rows plugin to our known `plugins`, and replaced the in
 
 ## <a name="persisting-documents" /> Persisting Documents
 
-So far, we haven't talked about how you'd persist the documents created by the editor. The editor keeps track of its own state
-(and additional things like what document is currently focused, etc.), but does not actually persist the state. One way to tie
-the editor to your actual backend is to add a change listener:
+So far, we haven't talked about how you'd persist the documents created by the
+editor. The editor keeps track of its own state (and additional things like what
+document is currently focused, etc.), but does not actually persist the state.
+One way to tie the editor to your actual backend is to add a change listener:
 
 ```tsx
 import { Editor } from '@edtr-io/core'
@@ -208,11 +223,14 @@ export default function App() {
 
 The change listener receives an object containing `changed` and `getDocument`:
 
-- `changed` is a boolean that tells you whether there are any pending changes (compared to the initial state you provided).
-  You may use this to disable a save button, for example.
-- `getDocument` is a function that returns the serialized document (e.g. to persist in a database, file, local storage, etc.). Since this operation
-  gets more expensive the longer the document is, you should decide yourself when you really need the serialized document (e.g. when the user actually
-  presses a save button or by some time-based autosave).
+- `changed` is a boolean that tells you whether there are any pending changes
+  (compared to the initial state you provided). You may use this to disable a
+  save button, for example.
+- `getDocument` is a function that returns the serialized document (e.g. to
+  persist in a database, file, local storage, etc.). Since this operation gets
+  more expensive the longer the document is, you should decide yourself when you
+  really need the serialized document (e.g. when the user actually presses a
+  save button or by some time-based autosave).
 
 <Note>
   If your backend is only able to handle strings, you still need to stringify
@@ -227,19 +245,24 @@ The change listener receives an object containing `changed` and `getDocument`:
 
 ## <a name="writing-plugins" /> Writing Plugins
 
-Until now, we only used "official" Edtr.io plugins. While these plugins are often heavily customizable, it is often helpful to create domain-specific
+Until now, we only used "official" Edtr.io plugins. While these plugins are
+often heavily customizable, it is often helpful to create domain-specific
 plugins that are tied to your own use case.
 
 An Edtr.io plugin consists of the following parts:
 
 - A React Component that defines how the plugin is rendered in the editor
-- A description of the state (including how the state should be serialized if needed)
-- A plugin configuration that allows to change the behavior of the plugin in different contexts
-- Optionally, some overrides of the Edtr.io default behavior (e.g. disabling default Edtr.io hotkey bindings)
+- A description of the state (including how the state should be serialized if
+  needed)
+- A plugin configuration that allows to change the behavior of the plugin in
+  different contexts
+- Optionally, some overrides of the Edtr.io default behavior (e.g. disabling
+  default Edtr.io hotkey bindings)
 
 ### Example: a Counter Plugin
 
-For educational purposes, let's define a simple plugin that represents a counter.
+For educational purposes, let's define a simple plugin that represents a
+counter.
 
 Firstly, we need to install another package intended for plugin developers:
 
@@ -263,11 +286,14 @@ Edtr.io has the concept of a so-called "state type". A state type encapsulates:
 - The structure of the state used at runtime
 - How the state is going to be serialized
 - What the initial state should look like
-- State type specific helpers intended to make development easier (e.g. handling file uploads)
+- State type specific helpers intended to make development easier (e.g. handling
+  file uploads)
 
-The goals are similar to React hooks. And similarly to React hooks, Edtr.io already provides state types for the most typical use cases.
+The goals are similar to React hooks. And similarly to React hooks, Edtr.io
+already provides state types for the most typical use cases.
 
-In our counter plugin, we can just use the `number` state type that represents - surprise - a number, and accepts the initial value (0 in our case).
+In our counter plugin, we can just use the `number` state type that represents -
+surprise - a number, and accepts the initial value (0 in our case).
 
 Next, we define how the counter plugin is rendered:
 
@@ -300,15 +326,24 @@ function CounterEditor({ editable, focused, state }) {
 }
 ```
 
-The component of an Edtr.io plugin receives - among other things - the following props:
+The component of an Edtr.io plugin receives - among other things - the following
+props:
 
-- `editable` is a boolean that tells you whether your plugin is editable. You can use this to hide editor-only elements when the document is not editable.
-- `focused` is a boolean that tells you whether your plugin is currently focused. You may use this to hide some elements when the user is editing a different document
-  at the moment (to get a better WYSIWYG feeling). There are also ways to check whether any of your child documents are focused (that isn't in the scope of this tutorial, though).
-- `state` contains the helpers defined by the state type used by your plugin. In our example, `state.value` contains the current counter value and `state.set` can be used
-  to update the state (similarly to React's `setState`, you may also provide an update callback to make sure that you actually use the current state).
+- `editable` is a boolean that tells you whether your plugin is editable. You
+  can use this to hide editor-only elements when the document is not editable.
+- `focused` is a boolean that tells you whether your plugin is currently
+  focused. You may use this to hide some elements when the user is editing a
+  different document at the moment (to get a better WYSIWYG feeling). There are
+  also ways to check whether any of your child documents are focused (that isn't
+  in the scope of this tutorial, though).
+- `state` contains the helpers defined by the state type used by your plugin. In
+  our example, `state.value` contains the current counter value and `state.set`
+  can be used to update the state (similarly to React's `setState`, you may also
+  provide an update callback to make sure that you actually use the current
+  state).
 
-In our counter example, we render the current value (surrounded by two buttons to decrement or increment the state respectively, if the document is editable).
+In our counter example, we render the current value (surrounded by two buttons
+to decrement or increment the state respectively, if the document is editable).
 
 Tying these things together, we have an Edtr.io plugin definition:
 
@@ -322,8 +357,10 @@ const counterPlugin = {
 
 ### Example: a Card Plugin
 
-Let's explore a more complicated example: a card. A card consists of a `title` and its `content` (which should be just some nested Edtr.io document).
-When you want to combine multiple values in your state, you can use the `object` state type. To render child documents, there is the `child` state type:
+Let's explore a more complicated example: a card. A card consists of a `title`
+and its `content` (which should be just some nested Edtr.io document). When you
+want to combine multiple values in your state, you can use the `object` state
+type. To render child documents, there is the `child` state type:
 
 ```tsx
 import { child, string, object } from '@edtr-io/plugin'
@@ -334,14 +371,17 @@ const cardState = object({
 })
 ```
 
-State types are composable by design. For example, the `object` state type expects a mapping of arbitrary keys to state types (and exposes those
-as an object to the plugin developer). The `string` state type pretty much works the same as the `number` state type. The `child` state type expects
-an object with
+State types are composable by design. For example, the `object` state type
+expects a mapping of arbitrary keys to state types (and exposes those as an
+object to the plugin developer). The `string` state type pretty much works the
+same as the `number` state type. The `child` state type expects an object with
 
-- `plugin` that describes the plugin that should be used by the child (as defined in `plugins`),
+- `plugin` that describes the plugin that should be used by the child (as
+  defined in `plugins`),
 - optional `initialState` to override the initial state used by the plugin,
-- optional `config` to (deeply) override the plugin configuration. For example, we could override the `plugins` of the rows plugin or override
-  the `placeholder` used by the text plugin.
+- optional `config` to (deeply) override the plugin configuration. For example,
+  we could override the `plugins` of the rows plugin or override the
+  `placeholder` used by the text plugin.
 
 We can use the state type as follows:
 
@@ -376,6 +416,8 @@ function CardEditor({ editable, state }) {
 
 ## Where to go from here
 
-- Look at the [official core plugins](https://github.com/edtr-io/edtr-io/tree/master/packages/plugins). You can check their source code to see how things work.
+- Look at the [official core
+  plugins](https://github.com/edtr-io/edtr-io/tree/master/packages/plugins). You
+  can check their source code to see how things work.
 - Check the [available state types](/api/plugin).
 - Explore the [API Reference](/api).

--- a/v1.1.0/docs/01-why.mdx
+++ b/v1.1.0/docs/01-why.mdx
@@ -1,22 +1,26 @@
 # Why?
 
-Edtr.io was born from the needs of the learning platform [serlo.org](https://serlo.org/)
-and with all the experience we gathered from creating educational resources by a diverse group of authors.
+Edtr.io was born from the needs of the learning platform
+[serlo.org](https://serlo.org/) and with all the experience we gathered from
+creating educational resources by a diverse group of authors.
 
-We tried out a lot of other editing libraries before we settled on creating our own
-(like [Slate](https://www.slatejs.org/) or [Draft.js](https://draftjs.org/)).
-However we noticed that the rich text part is only a small (albeit very important) foundation of what we need.
+We tried out a lot of other editing libraries before we settled on creating our
+own (like [Slate](https://www.slatejs.org/) or
+[Draft.js](https://draftjs.org/)). However we noticed that the rich text part is
+only a small (albeit very important) foundation of what we need.
 
-When creating interactive learning resources, we need more functionality than a rich text library can offer.
-Take for example multiple choice exercises and interactive learning games: Providing a great editing experience
-for these often requires us to have a tight control over the user experience.
-Trying to achieve that with a rich text library like Slate was hard:
+When creating interactive learning resources, we need more functionality than a
+rich text library can offer. Take for example multiple choice exercises and
+interactive learning games: Providing a great editing experience for these often
+requires us to have a tight control over the user experience. Trying to achieve
+that with a rich text library like Slate was hard:
 
-- Since Slate plugins are build around rich text editing, you often have to deal with rather low-level
-  details like text selection.
-- For Slate to do its magic, you also have to adhere to a couple of assumptions. Depending on what
-  you want to render, you might break something (e.g. your plugin loses it's focus).
+- Since Slate plugins are build around rich text editing, you often have to deal
+  with rather low-level details like text selection.
+- For Slate to do its magic, you also have to adhere to a couple of assumptions.
+  Depending on what you want to render, you might break something (e.g. your
+  plugin loses it's focus).
 
 These reasons lead us to build with Edtr.io an abstraction layer on top of that:
-A composable plugin system representing a tree of content elements where rich text is only contained
-in the leaf nodes.
+A composable plugin system representing a tree of content elements where rich
+text is only contained in the leaf nodes.

--- a/v1.1.0/docs/02-getting-started.mdx
+++ b/v1.1.0/docs/02-getting-started.mdx
@@ -1,6 +1,7 @@
 # Getting Started
 
-We create our own Edtr.io-powered WYSIWYG editor during this tutorial. It is divided into several sections:
+We create our own Edtr.io-powered WYSIWYG editor during this tutorial. It is
+divided into several sections:
 
 - [Setup](#setup)
 - [Creating the editor](#creating-the-editor)
@@ -10,7 +11,8 @@ We create our own Edtr.io-powered WYSIWYG editor during this tutorial. It is div
 
 ## Prerequisites
 
-We'll assume that you are familiar with React and the npm ecosystem. If you need to review your knowledge, we recommend the
+We'll assume that you are familiar with React and the npm ecosystem. If you need
+to review your knowledge, we recommend the
 [official React Tutorial](https://reactjs.org/tutorial/tutorial.html).
 
 ## <a name="setup" /> Setup
@@ -24,8 +26,9 @@ yarn add @edtr-io/core@^1.0.0 react@^16.8.0 react-dom@^16.8.0 react-is@^16.8.0 r
 npm i --save @edtr-io/core@^1.0.0 react@^16.8.0 react-dom@^16.8.0 react-is@^16.8.0 react-dnd@^11.0.0 react-dnd-html5-backend@^11.0.0 redux@^4.0.0 styled-components@^5.0.0
 ```
 
-Furthermore, we need at least one plugin. There are some "official" plugins provided by Edtr.io (though none of these are required). Let's start
-with the text plugin:
+Furthermore, we need at least one plugin. There are some "official" plugins
+provided by Edtr.io (though none of these are required). Let's start with the
+text plugin:
 
 ```bash
 # Using yarn
@@ -65,30 +68,38 @@ export default function App() {
   line <code>import 'regenerator-runtime/runtime'</code> to the top of the file.
 </Note>
 
-At this point, we should have a glorified rich-text editor. Let's go over the things we did in detail:
+At this point, we should have a glorified rich-text editor. Let's go over the
+things we did in detail:
 
-Firstly, we initialized an Edtr.io plugin using the `createTextPlugin` factory provided by `@edtr-io/plugin-text`.
-Like every "official" Edtr.io plugin, this factory accepts a config specific to the plugin. Some options are required
-(e.g. `registry`), while others are optional (e.g. `placeholder`).
+Firstly, we initialized an Edtr.io plugin using the `createTextPlugin` factory
+provided by `@edtr-io/plugin-text`. Like every "official" Edtr.io plugin, this
+factory accepts a config specific to the plugin. Some options are required (e.g.
+`registry`), while others are optional (e.g. `placeholder`).
 
 <Note>
   The factory pattern used by the "official" Edtr.io plugins is only a
   convention. Feel free to write your own plugins the way you like.
 </Note>
 
-After that, we specified the plugins that our editor should know about. This is a mapping of (arbitrary) keys to Edtr.io plugins.
-You can name the plugins how you prefer (e.g. `rich-text` instead of `text`), and they will appear in the serialized Edtr.io state.
+After that, we specified the plugins that our editor should know about. This is
+a mapping of (arbitrary) keys to Edtr.io plugins. You can name the plugins how
+you prefer (e.g. `rich-text` instead of `text`), and they will appear in the
+serialized Edtr.io state.
 
-The last thing we need is the state our editor should start with. The state describes an Edtr.io document and will be used to initialize
-the store. A document consists of the plugin used (i.e. with the same name as declared in `plugins`) and an optional state. If no
-state is provided (like in our example), the plugin creates its own initial state (e.g. empty text in our case).
+The last thing we need is the state our editor should start with. The state
+describes an Edtr.io document and will be used to initialize the store. A
+document consists of the plugin used (i.e. with the same name as declared in
+`plugins`) and an optional state. If no state is provided (like in our example),
+the plugin creates its own initial state (e.g. empty text in our case).
 
-Lastly, we render the `Editor` component provided by `@edtr-io/core` with the allowed plugins and the initial state.
+Lastly, we render the `Editor` component provided by `@edtr-io/core` with the
+allowed plugins and the initial state.
 
 ## <a name="nesting-documents" /> Nesting Documents
 
-The whole thing becomes much more interesting when we nest documents: Plugins may contain other Edtr.io documents and therefore create a tree
-of documents. The rows plugin provided by Edtr.io, for example, renders a list of documents.
+The whole thing becomes much more interesting when we nest documents: Plugins
+may contain other Edtr.io documents and therefore create a tree of documents.
+The rows plugin provided by Edtr.io, for example, renders a list of documents.
 
 First, we install the rows plugin
 
@@ -137,9 +148,12 @@ export default function App() {
 }
 ```
 
-We created the rows plugin via `createRowsPlugin` similarly to our text plugin. The rows plugin requires `content` which specifies which plugin
-should be used by default, and `plugins` which defines the plugins that may be added, including some metadata (e.g. a human-readable `title`).
-After that, we added the rows plugin to our known `plugins`, and replaced the initial state to start with the rows plugin.
+We created the rows plugin via `createRowsPlugin` similarly to our text plugin.
+The rows plugin requires `content` which specifies which plugin should be used
+by default, and `plugins` which defines the plugins that may be added, including
+some metadata (e.g. a human-readable `title`). After that, we added the rows
+plugin to our known `plugins`, and replaced the initial state to start with the
+rows plugin.
 
 <Note>
   The <code>plugins</code> passed to the <code>Editor</code> component are not
@@ -155,9 +169,10 @@ After that, we added the rows plugin to our known `plugins`, and replaced the in
 
 ## <a name="persisting-documents" /> Persisting Documents
 
-So far, we haven't talked about how you'd persist the documents created by the editor. The editor keeps track of its own state
-(and additional things like what document is currently focused, etc.), but does not actually persist the state. One way to tie
-the editor to your actual backend is to add a change listener:
+So far, we haven't talked about how you'd persist the documents created by the
+editor. The editor keeps track of its own state (and additional things like what
+document is currently focused, etc.), but does not actually persist the state.
+One way to tie the editor to your actual backend is to add a change listener:
 
 ```tsx
 import { Editor } from '@edtr-io/core'
@@ -208,11 +223,14 @@ export default function App() {
 
 The change listener receives an object containing `changed` and `getDocument`:
 
-- `changed` is a boolean that tells you whether there are any pending changes (compared to the initial state you provided).
-  You may use this to disable a save button, for example.
-- `getDocument` is a function that returns the serialized document (e.g. to persist in a database, file, local storage, etc.). Since this operation
-  gets more expensive the longer the document is, you should decide yourself when you really need the serialized document (e.g. when the user actually
-  presses a save button or by some time-based autosave).
+- `changed` is a boolean that tells you whether there are any pending changes
+  (compared to the initial state you provided). You may use this to disable a
+  save button, for example.
+- `getDocument` is a function that returns the serialized document (e.g. to
+  persist in a database, file, local storage, etc.). Since this operation gets
+  more expensive the longer the document is, you should decide yourself when you
+  really need the serialized document (e.g. when the user actually presses a
+  save button or by some time-based autosave).
 
 <Note>
   If your backend is only able to handle strings, you still need to stringify
@@ -227,19 +245,24 @@ The change listener receives an object containing `changed` and `getDocument`:
 
 ## <a name="writing-plugins" /> Writing Plugins
 
-Until now, we only used "official" Edtr.io plugins. While these plugins are often heavily customizable, it is often helpful to create domain-specific
+Until now, we only used "official" Edtr.io plugins. While these plugins are
+often heavily customizable, it is often helpful to create domain-specific
 plugins that are tied to your own use case.
 
 An Edtr.io plugin consists of the following parts:
 
 - A React Component that defines how the plugin is rendered in the editor
-- A description of the state (including how the state should be serialized if needed)
-- A plugin configuration that allows to change the behavior of the plugin in different contexts
-- Optionally, some overrides of the Edtr.io default behavior (e.g. disabling default Edtr.io hotkey bindings)
+- A description of the state (including how the state should be serialized if
+  needed)
+- A plugin configuration that allows to change the behavior of the plugin in
+  different contexts
+- Optionally, some overrides of the Edtr.io default behavior (e.g. disabling
+  default Edtr.io hotkey bindings)
 
 ### Example: a Counter Plugin
 
-For educational purposes, let's define a simple plugin that represents a counter.
+For educational purposes, let's define a simple plugin that represents a
+counter.
 
 Firstly, we need to install another package intended for plugin developers:
 
@@ -263,11 +286,14 @@ Edtr.io has the concept of a so-called "state type". A state type encapsulates:
 - The structure of the state used at runtime
 - How the state is going to be serialized
 - What the initial state should look like
-- State type specific helpers intended to make development easier (e.g. handling file uploads)
+- State type specific helpers intended to make development easier (e.g. handling
+  file uploads)
 
-The goals are similar to React hooks. And similarly to React hooks, Edtr.io already provides state types for the most typical use cases.
+The goals are similar to React hooks. And similarly to React hooks, Edtr.io
+already provides state types for the most typical use cases.
 
-In our counter plugin, we can just use the `number` state type that represents - surprise - a number, and accepts the initial value (0 in our case).
+In our counter plugin, we can just use the `number` state type that represents -
+surprise - a number, and accepts the initial value (0 in our case).
 
 Next, we define how the counter plugin is rendered:
 
@@ -300,15 +326,24 @@ function CounterEditor({ editable, focused, state }) {
 }
 ```
 
-The component of an Edtr.io plugin receives - among other things - the following props:
+The component of an Edtr.io plugin receives - among other things - the following
+props:
 
-- `editable` is a boolean that tells you whether your plugin is editable. You can use this to hide editor-only elements when the document is not editable.
-- `focused` is a boolean that tells you whether your plugin is currently focused. You may use this to hide some elements when the user is editing a different document
-  at the moment (to get a better WYSIWYG feeling). There are also ways to check whether any of your child documents are focused (that isn't in the scope of this tutorial, though).
-- `state` contains the helpers defined by the state type used by your plugin. In our example, `state.value` contains the current counter value and `state.set` can be used
-  to update the state (similarly to React's `setState`, you may also provide an update callback to make sure that you actually use the current state).
+- `editable` is a boolean that tells you whether your plugin is editable. You
+  can use this to hide editor-only elements when the document is not editable.
+- `focused` is a boolean that tells you whether your plugin is currently
+  focused. You may use this to hide some elements when the user is editing a
+  different document at the moment (to get a better WYSIWYG feeling). There are
+  also ways to check whether any of your child documents are focused (that isn't
+  in the scope of this tutorial, though).
+- `state` contains the helpers defined by the state type used by your plugin. In
+  our example, `state.value` contains the current counter value and `state.set`
+  can be used to update the state (similarly to React's `setState`, you may also
+  provide an update callback to make sure that you actually use the current
+  state).
 
-In our counter example, we render the current value (surrounded by two buttons to decrement or increment the state respectively, if the document is editable).
+In our counter example, we render the current value (surrounded by two buttons
+to decrement or increment the state respectively, if the document is editable).
 
 Tying these things together, we have an Edtr.io plugin definition:
 
@@ -322,8 +357,10 @@ const counterPlugin = {
 
 ### Example: a Card Plugin
 
-Let's explore a more complicated example: a card. A card consists of a `title` and its `content` (which should be just some nested Edtr.io document).
-When you want to combine multiple values in your state, you can use the `object` state type. To render child documents, there is the `child` state type:
+Let's explore a more complicated example: a card. A card consists of a `title`
+and its `content` (which should be just some nested Edtr.io document). When you
+want to combine multiple values in your state, you can use the `object` state
+type. To render child documents, there is the `child` state type:
 
 ```tsx
 import { child, string, object } from '@edtr-io/plugin'
@@ -334,14 +371,17 @@ const cardState = object({
 })
 ```
 
-State types are composable by design. For example, the `object` state type expects a mapping of arbitrary keys to state types (and exposes those
-as an object to the plugin developer). The `string` state type pretty much works the same as the `number` state type. The `child` state type expects
-an object with
+State types are composable by design. For example, the `object` state type
+expects a mapping of arbitrary keys to state types (and exposes those as an
+object to the plugin developer). The `string` state type pretty much works the
+same as the `number` state type. The `child` state type expects an object with
 
-- `plugin` that describes the plugin that should be used by the child (as defined in `plugins`),
+- `plugin` that describes the plugin that should be used by the child (as
+  defined in `plugins`),
 - optional `initialState` to override the initial state used by the plugin,
-- optional `config` to (deeply) override the plugin configuration. For example, we could override the `plugins` of the rows plugin or override
-  the `placeholder` used by the text plugin.
+- optional `config` to (deeply) override the plugin configuration. For example,
+  we could override the `plugins` of the rows plugin or override the
+  `placeholder` used by the text plugin.
 
 We can use the state type as follows:
 
@@ -376,6 +416,8 @@ function CardEditor({ editable, state }) {
 
 ## Where to go from here
 
-- Look at the [official core plugins](https://github.com/edtr-io/edtr-io/tree/master/packages/plugins). You can check their source code to see how things work.
+- Look at the [official core
+  plugins](https://github.com/edtr-io/edtr-io/tree/master/packages/plugins). You
+  can check their source code to see how things work.
 - Check the [available state types](/api/plugin).
 - Explore the [API Reference](/api).

--- a/v1.1.0/docs/03-architecture.mdx
+++ b/v1.1.0/docs/03-architecture.mdx
@@ -4,25 +4,34 @@ Edtr.io is designed along several guiding principles:
 
 ## <a name="principle1" /> Edtr.io should work with nearly every technology stack.
 
-The only assumption we make regarding your technology stack: the part of your app that integrates
-the Edtr.io editor needs to be able to render React components and users editing the content need to
-have JavaScript activated.
+The only assumption we make regarding your technology stack: the part of your
+app that integrates the Edtr.io editor needs to be able to render React
+components and users editing the content need to have JavaScript activated.
 
-For rendering the content, you can work around those assumptions if they do not fit your use case (see also [The overhead cost of rendering Edtr.io documents should be minimal compared to a barebone approach.](#principle2)).
+For rendering the content, you can work around those assumptions if they do not
+fit your use case (see also [The overhead cost of rendering Edtr.io documents
+should be minimal compared to a barebone approach.](#principle2)).
 
-Apart from that, you should be able to integrate Edtr.io into any app. We make no assumptions about
-how and where you persist your data.
+Apart from that, you should be able to integrate Edtr.io into any app. We make
+no assumptions about how and where you persist your data.
 
 ## <a name="principle2" /> The overhead cost of rendering Edtr.io documents should be minimal compared to a barebone approach.
 
-We provide a lightweight React component that renders Edtr.io documents using the plugins you provide.
-This already enables you to adapt the integration to your specific use case, e.g.:
+We provide a lightweight React component that renders Edtr.io documents using
+the plugins you provide. This already enables you to adapt the integration to
+your specific use case, e.g.:
 
-- You can use a [rendering approach](https://developers.google.com/web/updates/2019/02/rendering-on-the-web) that suits your use case the best (utilizing the existing React ecosystem).
-- You can optimize the bundle size for your end users (that view the content) by removing the parts that are only needed in the editor (e.g. toolbars).
+- You can use a [rendering
+  approach](https://developers.google.com/web/updates/2019/02/rendering-on-the-web)
+  that suits your use case the best (utilizing the existing React ecosystem).
+- You can optimize the bundle size for your end users (that view the content) by
+  removing the parts that are only needed in the editor (e.g. toolbars).
 
-If you need more customization, you can also write your own custom renderer for pretty much any output format. Since the Edtr.io document format is easy to traverse, you would only need to
-define how your plugins are rendered in that specific output format (see also [The document format should be easy to work with](#principle5)).
+If you need more customization, you can also write your own custom renderer for
+pretty much any output format. Since the Edtr.io document format is easy to
+traverse, you would only need to define how your plugins are rendered in that
+specific output format (see also [The document format should be easy to work
+with](#principle5)).
 
 ## <a name="principle3" /> It should be easy to develop Edtr.io plugins for existing React components.
 
@@ -32,24 +41,31 @@ An Edtr.io plugin is a React component that receives some props via Edtr.io:
 - Some props containing runtime information, e.g. `focused`.
 - Some props that allow you to work with Edtr.io's UI, e.g. `renderIntoToolbar`.
 
-Apart from that, your React component can do whatever it likes and utilize the existing React ecosystem.
-And as long as you tell Edtr.io when your state changes (via the `state` prop), it will behave as any
-other Edtr.io plugin (e.g. provide global undo/redo history).
+Apart from that, your React component can do whatever it likes and utilize the
+existing React ecosystem. And as long as you tell Edtr.io when your state
+changes (via the `state` prop), it will behave as any other Edtr.io plugin (e.g.
+provide global undo/redo history).
 
 ## <a name="principle4" /> Most of the Edtr.io's UI and behavior should be customizable.
 
 You can customize nearly every aspect of Edtr.io if necessary, e.g.
 
-- @edtr-io/plugin-rows is an Edtr.io plugin that provides the Drag'n'Drop behavior. You can replace that with your own Edtr.io plugin if you want a different behavior.
-- The Edtr.io Editor component allows you to pass your own custom DocumentEditor. With this, you can replace
-  the default UI we provide (e.g. by moving the toolbar somewhere else).
+- @edtr-io/plugin-rows is an Edtr.io plugin that provides the Drag'n'Drop
+  behavior. You can replace that with your own Edtr.io plugin if you want a
+  different behavior.
+- The Edtr.io Editor component allows you to pass your own custom
+  DocumentEditor. With this, you can replace the default UI we provide (e.g. by
+  moving the toolbar somewhere else).
 
 ## <a name="principle5" /> The document format should be easy to work with.
 
-The serialized format of documents created by Edtr.io is a light-weight tree structure in JSON. It is also
-intended to be used/created outside of Edtr.io if necessary. This enables various use cases, for example:
+The serialized format of documents created by Edtr.io is a light-weight tree
+structure in JSON. It is also intended to be used/created outside of Edtr.io if
+necessary. This enables various use cases, for example:
 
-- You can convert your existing content that was not created with Edtr.io to Edtr.io's document format.
+- You can convert your existing content that was not created with Edtr.io to
+  Edtr.io's document format.
 - You can convert your content created by Edtr.io to some other format.
-- You can dynamically create a single Edtr.io document from multiple entities in your persistence layer.
+- You can dynamically create a single Edtr.io document from multiple entities in
+  your persistence layer.
 - …


### PR DESCRIPTION
* Set proseWrap=always (see https://prettier.io/docs/en/options.html#prose-wrap ) so that markdown files are also formated to a maximum line length
* Only format self written markdown files in `v*/docs/...` since `v*/api/...` are all generated (am I right?)